### PR TITLE
Removed ListBucket requirement, added error message

### DIFF
--- a/inc/S3BackUpService.php
+++ b/inc/S3BackUpService.php
@@ -562,19 +562,11 @@ class S3BackUpService extends Service {
 				$errors['bucket'] = __( 'Could not connect to S3', 'backupwordpress' );
 			} else {
 				try {
-					$result = $this->s3->listBuckets( array() );
+					$this->s3->headBucket(array(
+						'Bucket' => $new_data['bucket'],
+					));
 				} catch ( \Exception $e ) {
-					$errors['bucket'] = sprintf( __( '%s', 'backupwordpress' ), $e->getMessage() );
-				}
-				$buckets = '';
-				if ( isset( $result['Buckets'] ) ) {
-					$buckets = wp_list_pluck( $result['Buckets'], 'Name' );
-				} else {
-					$errors['bucket'] = __( 'No buckets retrieved', 'backupwordpress' );
-				}
-
-				if ( $buckets && ! in_array( $new_data['bucket'], $buckets ) ) {
-					$errors['bucket'] = __( 'Bucket does not exist', 'backupwordpress' );
+					$errors['bucket'] = sprintf( __( 'Bucket error: %s', 'backupwordpress' ), $e->getMessage() );
 				}
 			}
 		}


### PR DESCRIPTION
Using headBucket, we can test for bucket existance and access permissions.

Also gives a much better error when you are missing permissions instead of giving a missing bucket error.

Fixes https://github.com/humanmade/backupwordpress-pro-s3/issues/25